### PR TITLE
Fix remember-me option in admin login

### DIFF
--- a/admin_routes.py
+++ b/admin_routes.py
@@ -23,7 +23,7 @@ def admin_login():
         admin = Admin.query.filter_by(username=form.username.data).first()
         
         if admin and check_password_hash(admin.password_hash, form.password.data):
-            login_user(admin)
+            login_user(admin, remember=form.remember.data)
             next_page = request.args.get('next')
             return redirect(next_page or url_for('admin_dashboard'))
         else:


### PR DESCRIPTION
## Summary
- ensure admin login honors 'remember me' checkbox

## Testing
- `python -m py_compile admin_routes.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684040b59c088323a55773a5babf7567