### PR TITLE
Use env for admin credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL=sqlite:///portfolio.db
+SESSION_SECRET=your_secret_key
+ADMIN_USER=admin
+ADMIN_PASS=MS

--- a/app.py
+++ b/app.py
@@ -68,9 +68,9 @@ with app.app_context():
         if not Admin.query.first():
             from werkzeug.security import generate_password_hash
             admin = Admin()
-            admin.username = 'admin'
+            admin.username = os.environ.get('ADMIN_USER', 'admin')
             admin.email = 'admin@admin.com'
-            admin.password_hash = generate_password_hash('MS')
+            admin.password_hash = generate_password_hash(os.environ.get('ADMIN_PASS', 'MS'))
             db.session.add(admin)
             db.session.commit()
             logging.info("Created default admin user")

--- a/db_reset.py
+++ b/db_reset.py
@@ -14,9 +14,9 @@ def init_db():
         # Default admin kullanıcısını ekle
         if Admin.query.count() == 0:
             admin = Admin(
-                username="admin",
+                username=os.environ.get("ADMIN_USER", "admin"),
                 email="admin@kilinchukuk.com",
-                password_hash=generate_password_hash("MS")
+                password_hash=generate_password_hash(os.environ.get("ADMIN_PASS", "MS"))
             )
             db.session.add(admin)
             print("Default admin kullanıcısı oluşturuldu.")

--- a/db_setup.py
+++ b/db_setup.py
@@ -1,3 +1,4 @@
+import os
 from app import app, db
 from models import Admin, Settings, User, SocialMedia
 from werkzeug.security import generate_password_hash
@@ -11,9 +12,9 @@ def setup_db():
         
         # Default admin kullanıcısını ekle
         admin = Admin()
-        admin.username = "admin"
+        admin.username = os.environ.get("ADMIN_USER", "admin")
         admin.email = "admin@kilinchukuk.com"
-        admin.password_hash = generate_password_hash("MS")
+        admin.password_hash = generate_password_hash(os.environ.get("ADMIN_PASS", "MS"))
         db.session.add(admin)
         
         # Varsayılan site ayarlarını ekle


### PR DESCRIPTION
## Summary
- fetch admin credentials from environment in app and setup scripts
- document example admin variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68434000fc388323bdd74bef96230874