### PR TITLE
Fix contact form value retention

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -242,20 +242,32 @@ def iletisim():
     
     # Initialize contact form
     form = ContactForm()
-    
+
     # Process contact form submission
     if request.method == 'POST':
+        form = ContactForm(request.form)
+
         # Validate CSRF token
         form_token = request.form.get('csrf_token')
         if not form_token or form_token != session['csrf_token']:
             flash('Güvenlik doğrulaması başarısız oldu.', 'danger')
-            return redirect(url_for('iletisim'))
-        
+            session['captcha_code'] = generate_captcha_code()
+            return render_template('contact.html',
+                                 settings=settings,
+                                 user=user,
+                                 social=social,
+                                 form=form)
+
         # Validate captcha
         captcha_input = request.form.get('captcha')
         if not captcha_input or captcha_input != session.get('captcha_code'):
             flash('Güvenlik kodu hatalı.', 'danger')
-            return redirect(url_for('iletisim'))
+            session['captcha_code'] = generate_captcha_code()
+            return render_template('contact.html',
+                                 settings=settings,
+                                 user=user,
+                                 social=social,
+                                 form=form)
         
         # Create a new contact message
         new_message = Contact(

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -52,19 +52,19 @@
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <div class="form-group">
                         <label for="full_name" class="form-label">Adınız Soyadınız</label>
-                        <input type="text" class="form-control" id="full_name" name="full_name" required>
+                        <input type="text" class="form-control" id="full_name" name="full_name" value="{{ request.form.get('full_name', '') }}" required>
                     </div>
                     <div class="form-group">
                         <label for="email" class="form-label">E-posta Adresiniz</label>
-                        <input type="email" class="form-control" id="email" name="email" required>
+                        <input type="email" class="form-control" id="email" name="email" value="{{ request.form.get('email', '') }}" required>
                     </div>
                     <div class="form-group">
                         <label for="subject" class="form-label">Konu</label>
-                        <input type="text" class="form-control" id="subject" name="subject" required>
+                        <input type="text" class="form-control" id="subject" name="subject" value="{{ request.form.get('subject', '') }}" required>
                     </div>
                     <div class="form-group">
                         <label for="message" class="form-label">Mesajınız</label>
-                        <textarea class="form-control" id="message" name="message" rows="5" maxlength="2000" oninput="updateCharCount()" required></textarea>
+                        <textarea class="form-control" id="message" name="message" rows="5" maxlength="2000" oninput="updateCharCount()" required>{{ request.form.get('message', '') }}</textarea>
                         <div id="char-count" class="char-count">0 / 2000</div>
                     </div>
                     <div class="captcha-container">
@@ -99,6 +99,7 @@ function updateCharCount() {
         info.style.color = '#888';
     }
 }
+document.addEventListener('DOMContentLoaded', updateCharCount);
 </script>
 {% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- show previously submitted values when re-rendering the contact form
- return the contact template when captcha/CSRF validation fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement email-validator)*

------
https://chatgpt.com/codex/tasks/task_e_6843479cca008323af3f9659d3dac37a